### PR TITLE
Allow use against single packages and copyright files

### DIFF
--- a/dpkg-licenses
+++ b/dpkg-licenses
@@ -26,19 +26,24 @@ case "$1" in
     cat >&2 <<.e
 Lists all installed packages (dpkg -l similar format) and prints their licenses
 
-Usage: $0
+Usage: $0 [PACKAGE_TO_CHECK]
+
+If PACKAGE_TO_CHECK is not given, will check all packages installed
 .e
     exit 1
+    ;;
 esac
 
 SCRIPTLIB=$(dirname $(readlink -f "$0"))/lib/
 test -d "$SCRIPTLIB"
 
+PACKAGES_TO_CHECK="$1"
+
 format='%-2s  %-30s %-30s %-6s %-60s %s\n'
 printf "$format" "St" "Name" "Version" "Arch" "Description" "Licenses"
 printf "$format" "--" "----" "-------" "----" "-----------" "--------"
 
-COLUMNS=2000 dpkg -l | grep '^.[iufhwt]' | while read pState package pVer pArch pDesc; do
+COLUMNS=2000 dpkg -l "${PACKAGES_TO_CHECK}" | grep '^.[iufhwt]' | while read pState package pVer pArch pDesc; do
   license=
   for method in "$SCRIPTLIB"/reader*; do
     [ -f "$method" ] || continue

--- a/lib/reader-30-fuzzy_common-licenses.sh
+++ b/lib/reader-30-fuzzy_common-licenses.sh
@@ -25,8 +25,13 @@
 set -e
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
+copyrightfile="$2"
+if [ -n "${copyrightfile}" ]; then
+    if [ ! -f "${copyrightfile}" ]; then
+        echo "ERROR: Specified copy right file not found: '${copyrightfile}'" >&2
+        exit 1  
+    fi
+elif [ -f "/usr/share/doc/$package/copyright" ]; then
   copyrightfile="/usr/share/doc/$package/copyright"
 elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
   copyrightfile="/usr/share/doc/${package%:*}/copyright"

--- a/lib/reader-50-superfuzzy.sh
+++ b/lib/reader-50-superfuzzy.sh
@@ -25,8 +25,13 @@
 set -e
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
+copyrightfile="$2"
+if [ -n "${copyrightfile}" ]; then
+    if [ ! -f "${copyrightfile}" ]; then
+        echo "ERROR: Specified copy right file not found: '${copyrightfile}'" >&2
+        exit 1  
+    fi
+elif [ -f "/usr/share/doc/$package/copyright" ]; then
   copyrightfile="/usr/share/doc/$package/copyright"
 elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
   copyrightfile="/usr/share/doc/${package%:*}/copyright"

--- a/lib/reader-70-free-licence.sh
+++ b/lib/reader-70-free-licence.sh
@@ -25,8 +25,13 @@
 set -e
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
+copyrightfile="$2"
+if [ -n "${copyrightfile}" ]; then
+    if [ ! -f "${copyrightfile}" ]; then
+        echo "ERROR: Specified copy right file not found: '${copyrightfile}'" >&2
+        exit 1  
+    fi
+elif [ -f "/usr/share/doc/$package/copyright" ]; then
   copyrightfile="/usr/share/doc/$package/copyright"
 elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
   copyrightfile="/usr/share/doc/${package%:*}/copyright"

--- a/lib/reader-99-dump-unreadable-file.sh
+++ b/lib/reader-99-dump-unreadable-file.sh
@@ -25,8 +25,13 @@
 set -e
 
 package="$1"
-copyrightfile=
-if [ -f "/usr/share/doc/$package/copyright" ]; then
+copyrightfile="$2"
+if [ -n "${copyrightfile}" ]; then
+    if [ ! -f "${copyrightfile}" ]; then
+        echo "ERROR: Specified copy right file not found: '${copyrightfile}'" >&2
+        exit 1  
+    fi
+elif [ -f "/usr/share/doc/$package/copyright" ]; then
   copyrightfile="/usr/share/doc/$package/copyright"
 elif [ -f "/usr/share/doc/${package%:*}/copyright" ]; then
   copyrightfile="/usr/share/doc/${package%:*}/copyright"


### PR DESCRIPTION
single packages:
To support getting license information from single packages instead for every
pacakge on the system

single copyright files (separate from a package):
to support getting information from a copyright file pulled from a package
archive. this makes it possible to evaluate the copyright file a package without
having to install the packge (extract the copyright file, use the reader
modules directly).