### PR TITLE
Improved detection for a few packages

### DIFF
--- a/lib/reader-10-Machine-readable-v1.sh
+++ b/lib/reader-10-Machine-readable-v1.sh
@@ -37,19 +37,19 @@ format=$(awk '/^Format:/{print}/^$/{exit}' "$copyrightfile")
 [ -n "$format" ] || exit 0
 
 case "$format" in
-  *'://www.debian.org/doc/packaging-manuals/copyright-format/1.0'*)
+  *'//www.debian.org/doc/packaging-manuals/copyright-format/1.0'*)
     result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
     ;;
-  *'http://dep.debian.net/deps/dep5'*)
+  *'//dep.debian.net/deps/dep5'*)
     result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
     ;;
-  *'http://anonscm.debian.org/viewvc/dep/web/deps/dep5.mdwn?'*)
+  *'//anonscm.debian.org/viewvc/dep/web/deps/dep5.mdwn?'*)
     result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
     ;;
-  *'http://svn.debian.org/wsvn/dep/web/deps/dep5.mdwn?'*)
+  *'//svn.debian.org/wsvn/dep/web/deps/dep5.mdwn?'*)
     result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
     ;;
-  *'http://anonscm.debian.org/loggerhead/dep/dep5/trunk/annotate/179/dep5/copyright-format.xml'*)
+  *'//anonscm.debian.org/loggerhead/dep/dep5/trunk/annotate/179/dep5/copyright-format.xml'*)
     result=$(grep '^License:' "$copyrightfile" | cut -d':' -f2-)
     ;;
   "Format:")  # seen in /usr/share/doc/libpcsclite1/copyright

--- a/lib/reader-50-superfuzzy.sh
+++ b/lib/reader-50-superfuzzy.sh
@@ -41,6 +41,7 @@ result=$(grep -Ewoi \
     -e 'Creative Commons( Licenses?)?' \
     -e 'Public Domain( Licenses?)?' \
     -e 'GNU General Public( License)?' \
+    -e 'Info-ZIP License' \
     "$copyrightfile" | sed -r -e 's/[Ll]icence/License/g' | sort -u)
 if [ -n "$result" ]; then
   echo "$result"

--- a/lib/reader-50-superfuzzy.sh
+++ b/lib/reader-50-superfuzzy.sh
@@ -40,6 +40,7 @@ result=$(grep -Ewoi \
     -e '(CCPL|BSD|L?GPL)-[0-9a-z.+-]+( Licenses?)?' \
     -e 'Creative Commons( Licenses?)?' \
     -e 'Public Domain( Licenses?)?' \
+    -e 'GNU General Public( License)?' \
     "$copyrightfile" | sed -r -e 's/[Ll]icence/License/g' | sort -u)
 if [ -n "$result" ]; then
   echo "$result"


### PR DESCRIPTION
**In reader-10-Machine-readable-v1.sh, match the URL without http/https schema**

- libslirp0: `Format: https://dep.debian.net/deps/dep5`
- libspice-server1: `Format: https://svn.debian.org/wsvn/dep/web/deps/dep5.mdwn?op=file&rev=174`
- linux-modules-nvidia-535-5.15.0-84-generic: `Format: //www.debian.org/doc/packaging-manuals/copyright-format/1.0/`

**reader-50-superfuzzy.sh**

- Add match for explicit "_GNU General Public License_" and "_Info-ZIP_".